### PR TITLE
Add DéliverableQueries and TaskQueries  Unit tests

### DIFF
--- a/backend/src/__tests__/DeliverableQueries.test.ts
+++ b/backend/src/__tests__/DeliverableQueries.test.ts
@@ -1,84 +1,91 @@
-// import { Status } from "../entities/Task";
-// import { faker } from "@faker-js/faker";
-// import { Deliverable } from "../entities/Deliverable";
-// import { DeliverableQueries } from "../graphql-resolvers/DeliverableQueries";
-// import { mockTypeOrm } from "../__tests_mockTypeorm-config";
+import { faker } from "@faker-js/faker";
+import { mockTypeOrm } from "../__tests_mockTypeorm-config";
+import { Deliverable } from "../entities/Deliverable";
+import { DeliverableQueries } from "../graphql-resolvers/DeliverableQueries";
+import { Status } from "../enums/Status";
 
-// describe("Deliverable Graphql queries", () => {
-//   let deliverableQueries: DeliverableQueries;
-//   let deliverables: Deliverable[];
+describe("Deliverable Queries", () => {
+  let deliverableQueries: DeliverableQueries;
 
-//   beforeEach(() => {
-//     deliverableQueries = new DeliverableQueries();
-//     deliverables = [
-//       new Deliverable(
-//         faker.lorem.sentence(),
-//         faker.commerce.productDescription(),
-//         faker.date.future(),
-//         faker.helpers.arrayElement([
-//           Status.NOT_STARTED,
-//           Status.BLOCKED,
-//           Status.IN_PROGRESS,
-//           Status.COMPLETED,
-//         ]),
-//         faker.date.future()
-//       ),
-//       new Deliverable(
-//         faker.lorem.sentence(),
-//         faker.commerce.productDescription(),
-//         faker.date.future(),
-//         faker.helpers.arrayElement([
-//           Status.NOT_STARTED,
-//           Status.BLOCKED,
-//           Status.IN_PROGRESS,
-//           Status.COMPLETED,
-//         ]),
-//         faker.date.future()
-//       ),
-//       new Deliverable(
-//         faker.lorem.sentence(),
-//         faker.commerce.productDescription(),
-//         faker.date.future(),
-//         faker.helpers.arrayElement([
-//           Status.NOT_STARTED,
-//           Status.BLOCKED,
-//           Status.IN_PROGRESS,
-//           Status.COMPLETED,
-//         ]),
-//         faker.date.future()
-//       ),
-//       new Deliverable(
-//         faker.lorem.sentence(),
-//         faker.commerce.productDescription(),
-//         faker.date.future(),
-//         faker.helpers.arrayElement([
-//           Status.NOT_STARTED,
-//           Status.BLOCKED,
-//           Status.IN_PROGRESS,
-//           Status.COMPLETED,
-//         ]),
-//         faker.date.future()
-//       ),
-//     ];
-//   });
+  beforeEach(() => {
+    deliverableQueries = new DeliverableQueries();
+  });
 
-//   describe("query all deliverables from TypeORM", () => {
-//     it("should return all deliverables", async () => {
-//       mockTypeOrm().onMock(Deliverable).toReturn(deliverables, "find");
-//       const allDeliverables: Deliverable[] =
-//         await deliverableQueries.getAllDeliverables();
-//       expect(allDeliverables).toMatchObject(deliverables);
-//     });
-//   });
+  // 1) getAllDeliverables
 
-//   describe("query a deliverable by id from TypeORM", () => {
-//     it("should return a deliverable by id", async () => {
-//       const deliverable: Deliverable = deliverables[0];
-//       mockTypeOrm().onMock(Deliverable).toReturn(deliverable, "findOne");
+  describe("getAllDeliverables", () => {
+    it("should return an array of deliverables", async () => {
+      // Préparation du tableau simulé
+      const deliverables: Deliverable[] = [
+        new Deliverable(
+          faker.lorem.word(),          // name
+          faker.lorem.sentence(),      // perimeter
+          faker.date.future().toISOString(), // deliveryDate
+           Status.IN_PROGRESS,               // status
+          faker.date.past().toISOString(),   // createdAt
+          faker.number.int({ min: 0, max: 3 }) // reviews
+        ),
+        new Deliverable(
+          faker.lorem.word(),
+          faker.lorem.sentence(),
+          faker.date.future().toISOString(),
+          Status.COMPLETED,
+          faker.date.past().toISOString(),
+          faker.number.int({ min: 0, max: 3 })
+        ),
+      ];
 
-//       const retrievedDeliverable: Deliverable | null =
-//         await deliverableQueries.getDeliverable(deliverable.id!);
-//       expect(retrievedDeliverable).toMatchObject(deliverable);
-//     });
-//   });
-// });
+      // Mock la méthode 'find'
+      mockTypeOrm().onMock(Deliverable).toReturn(deliverables, "find");
+
+      const result = await deliverableQueries.getAllDeliverables();
+
+      expect(result).toHaveLength(deliverables.length);
+      expect(result[0].name).toBe(deliverables[0].name);
+      expect(result[1].status).toBe(deliverables[1].status);
+    });
+
+    it("should return an empty array if no deliverables exist", async () => {
+      // Simule la BDD vide
+      mockTypeOrm().onMock(Deliverable).toReturn([], "find");
+
+      const result = await deliverableQueries.getAllDeliverables();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  // 2) getDeliverable
+
+  describe("getDeliverable", () => {
+    it("should return a deliverable if found", async () => {
+      // Création du deliverable
+      const existingDeliverable = new Deliverable(
+        faker.lorem.word(),
+        faker.lorem.sentence(),
+        faker.date.future().toISOString(),
+        Status.IN_PROGRESS,
+        faker.date.past().toISOString(),
+        faker.number.int({ min: 0, max: 3 })
+      );
+      existingDeliverable.id = 42;
+
+      mockTypeOrm().onMock(Deliverable).toReturn(existingDeliverable, "findOne");
+
+      const result = await deliverableQueries.getDeliverable(42);
+
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe(42);
+      expect(result?.name).toBe(existingDeliverable.name);
+    });
+
+    it("should return null if deliverable not found", async () => {
+      // Mock 'findOne' pour qu'il renvoie null
+      mockTypeOrm().onMock(Deliverable).toReturn(null, "findOne");
+
+      const result = await deliverableQueries.getDeliverable(9999);
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/backend/src/__tests__/TaskQueries.test.ts
+++ b/backend/src/__tests__/TaskQueries.test.ts
@@ -1,76 +1,85 @@
-// import { Task, Status } from "../entities/Task";
-// import { faker } from "@faker-js/faker";
-// import { TaskQueries } from "../graphql-resolvers/TaskQueries";
-// import { mockTypeOrm } from "../__tests_mockTypeorm-config";
+import { faker } from "@faker-js/faker";
+import { mockTypeOrm } from "../__tests_mockTypeorm-config";
+import { Task } from "../entities/Task";
+import { TaskQueries } from "../graphql-resolvers/TaskQueries";
 
-// describe("Task Graphql queries", () => {
-//   let taskQueries: TaskQueries;
-//   let tasks: Task[];
+describe("Task Queries", () => {
+  let taskQueries: TaskQueries;
 
-//   beforeEach(() => {
-//     taskQueries = new TaskQueries();
-//     tasks = [
-//       new Task(
-//         faker.lorem.sentence(),
-//         faker.commerce.productDescription(),
-//         faker.date.past(),
-//         faker.date.future(),
-//         faker.helpers.arrayElement([
-//           Status.NOT_STARTED,
-//           Status.BLOCKED,
-//           Status.IN_PROGRESS,
-//           Status.COMPLETED,
-//         ])
-//       ),
-//       new Task(
-//         faker.lorem.sentence(),
-//         faker.commerce.productDescription(),
-//         faker.date.past(),
-//         faker.date.future(),
-//         faker.helpers.arrayElement([
-//           Status.NOT_STARTED,
-//           Status.BLOCKED,
-//           Status.IN_PROGRESS,
-//           Status.COMPLETED,
-//         ])
-//       ),
-//       new Task(
-//         faker.lorem.sentence(),
-//         faker.commerce.productDescription(),
-//         faker.date.past(),
-//         faker.date.future(),
-//         faker.helpers.arrayElement([
-//           Status.NOT_STARTED,
-//           Status.BLOCKED,
-//           Status.IN_PROGRESS,
-//           Status.COMPLETED,
-//         ])
-//       ),
-//       new Task(
-//         faker.lorem.sentence(),
-//         faker.commerce.productDescription(),
-//         faker.date.past(),
-//         faker.date.future(),
-//         faker.helpers.arrayElement([
-//           Status.NOT_STARTED,
-//           Status.BLOCKED,
-//           Status.IN_PROGRESS,
-//           Status.COMPLETED,
-//         ])
-//       ),
-//     ];
-//   });
+  beforeEach(() => {
+    taskQueries = new TaskQueries();
+  });
 
-//   describe("query all tasks from TypeORM", () => {
-//     it("returns tasks from TypeORM", async () => {
-//       mockTypeOrm().onMock(Task).toReturn(tasks, "find");
-//       const retrievedTasks: Task[] = await taskQueries.getAllTasks();
-//       expect(retrievedTasks.length).toBe(tasks.length);
-//       expect(retrievedTasks[0]).toHaveProperty("name");
-//       expect(retrievedTasks[0]).toHaveProperty("description");
-//       expect(retrievedTasks[0]).toHaveProperty("startDate");
-//       expect(retrievedTasks[0]).toHaveProperty("endDate");
-//       expect(retrievedTasks[0]).toHaveProperty("status");
-//     });
-//   });
-// });
+
+  // 1) getAllTasks
+
+  describe("getAllTasks", () => {
+    it("should return an array of tasks", async () => {
+      // Préparation de taches fictives
+      const tasks: Task[] = [
+        new Task(
+          faker.lorem.words(2),
+          faker.lorem.sentence(),
+          faker.date.past().toISOString(),
+          faker.date.future().toISOString()
+        ),
+        new Task(
+          faker.lorem.words(2),
+          faker.lorem.sentence(),
+          faker.date.past().toISOString(),
+          faker.date.future().toISOString()
+        ),
+      ];
+
+      // Mock la méthode 'find' de TypeORM
+      mockTypeOrm().onMock(Task).toReturn(tasks, "find");
+
+      const result = await taskQueries.getAllTasks();
+
+      expect(result).toHaveLength(tasks.length);
+      expect(result[0].name).toBe(tasks[0].name);
+      expect(result[1].description).toBe(tasks[1].description);
+    });
+
+    it("should return an empty array if no tasks exist", async () => {
+      // Simulation d'une bdd vide
+      mockTypeOrm().onMock(Task).toReturn([], "find");
+
+      const result = await taskQueries.getAllTasks();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  // 2) getTask
+
+  describe("getTask", () => {
+    it("should return a single task if found", async () => {
+      const existingTask = new Task(
+        "Existing Task",
+        "Some description",
+        faker.date.past().toISOString(),
+        faker.date.future().toISOString()
+      );
+      existingTask.id = 42;
+
+      // Mock 'findOne' et renvoi la tache
+      mockTypeOrm().onMock(Task).toReturn(existingTask, "findOne");
+
+      const result = await taskQueries.getTask(42);
+
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe(42);
+      expect(result?.name).toBe("Existing Task");
+    });
+
+    it("should return null if task not found", async () => {
+      // findOne renvoie null ou undefined
+      mockTypeOrm().onMock(Task).toReturn(null, "findOne");
+
+      const result = await taskQueries.getTask(9999);
+
+      expect(result).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Add tests for TaskQueries and DeliverableQueries

### 📝 Description

This Pull Request adds unit tests for the following GraphQL query resolvers:

- `TaskQueries`
- `DeliverableQueries`

###  Implemented features

- Added tests for:
  - `getAllTasks()`
  - `getTask(id)`
  - `getAllDeliverables()`
  - `getDeliverable(id)`
- Mocked TypeORM interactions with `mockTypeOrm()` to isolate tests from the database.

### Corrections and improvements

- Ensured consistency in the test implementation and file structure.
- Used Faker to generate realistic test data.

### Implementation details

- Structured test suites using Jest (`describe`, `beforeEach`, `it`).
- Covered scenarios:
  - Successful retrieval of all items.
  - Successful retrieval of a single item by ID.
  - Retrieval of a non-existing item returning `null`.

### Test coverage

- All implemented tests passed successfully.
- Increased reliability and maintainability by validating expected resolver behavior.
