### PR TITLE
Add clients list page with Apollo query integration

### DIFF
--- a/frontend/src/graphql-queries/clients.ts
+++ b/frontend/src/graphql-queries/clients.ts
@@ -1,0 +1,14 @@
+import { gql } from "@apollo/client";
+
+export const GET_ALL_CLIENTS_QUERY = gql`
+  query GetAllClients {
+    getAllClients {
+      id
+      name
+      account {
+        id
+        email
+      }
+    }
+  }
+`;

--- a/frontend/src/pages/Clients.tsx
+++ b/frontend/src/pages/Clients.tsx
@@ -1,14 +1,48 @@
+import { useQuery } from "@apollo/client";
 import Navigation from "../components/Navigation";
+import { GET_ALL_CLIENTS_QUERY } from "../graphql-queries/clients";
+
+export interface Client {
+  id: number;
+  name: string;
+  account?: {
+    id: number;
+    email: string;
+  };
+}
+
+interface GetAllClientsData {
+  getAllClients: Client[];
+}
 
 export default function Clients() {
+  const { loading, error, data } = useQuery<GetAllClientsData>(
+    GET_ALL_CLIENTS_QUERY,
+  );
+
+  if (loading) return <p>Loading...</p>;
+  if (error) return <p>Error : {error.message}</p>;
+
   return (
     <div className="flex flex-col md:flex-row">
       <div className="md:w-20 md:flex-shrink-0">
         <Navigation />
       </div>
       <div className="flex-1 p-4 md:ml-4">
-        <h1>Welcome to the Clients Page</h1>
-        {/* Add your page content here */}
+        <h1>Liste des Clients</h1>
+        {data?.getAllClients?.length === 0 ? (
+          <p>Aucun client trouvé</p>
+        ) : (
+          <ul>
+            {data?.getAllClients.map((client) => (
+              <li key={client.id} className="mb-4 p-4 border rounded">
+                <strong>{client.name}</strong>
+                <br />
+                {client.account && <span>Email: {client.account.email}</span>}
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Client list page Implementation

**Description:**

Adds to the clients page, the retrieval of all clients via the GraphQL API to and from Apollo Client. 
It displays all clients with their names and email addresses when available.

**Features:**
- Integration of Apollo Client for data retrieval
- Loading and management of error states
- TypeScript interfaces for the customer data model
