### PR TITLE
Create account

### DIFF
--- a/backend/src/graphql-resolvers/AccountMutation.ts
+++ b/backend/src/graphql-resolvers/AccountMutation.ts
@@ -21,7 +21,7 @@ export class AccountMutation {
         where: { email },
       });
       if (existingAccount) {
-        throw new Error("Email already exists");
+        throw new Error("Client already exists");
       }
 
       // Création de l'Account
@@ -31,7 +31,7 @@ export class AccountMutation {
       return newAccount;
     } catch (error) {
       console.error("Error creating account:", error);
-      throw new Error("Failed to create account");
+      throw new Error("Failed to create account! Please try again.");
     }
   }
 }

--- a/backend/src/graphql-resolvers/AccountMutation.ts
+++ b/backend/src/graphql-resolvers/AccountMutation.ts
@@ -11,6 +11,11 @@ export class AccountMutation {
     @Arg("role") role: Role,
   ): Promise<Account> {
     try {
+      console.log("Received data:", { email, password, role });
+
+      if (!dataSource.isInitialized) {
+        throw new Error("Database connection not initialized");
+      }
       // Vérification si l'email existe déjà
       const existingAccount = await dataSource.manager.findOne(Account, {
         where: { email },

--- a/backend/src/graphql-resolvers/ClientMutations.ts
+++ b/backend/src/graphql-resolvers/ClientMutations.ts
@@ -7,7 +7,7 @@ import { Mutation, Arg, Resolver } from "type-graphql";
 export class ClientMutations {
   @Mutation((_) => Client)
   async createClient(
-    @Arg("Name") name: string,
+    @Arg("name") name: string,
     @Arg("accountId") accountId: number,
   ): Promise<Client> {
     try {
@@ -28,7 +28,7 @@ export class ClientMutations {
       await dataSource.manager.save(newClient);
       return newClient;
     } catch (error) {
-      console.error(error);
+      console.error("erreur graphql", error);
       throw new Error("Failed to create client");
     }
   }

--- a/documentation/scripts/start.sh
+++ b/documentation/scripts/start.sh
@@ -1,5 +1,5 @@
 docker compose  -f docker-compose.dev.yml up --build -d --force-recreate
-docker compose -f docker-compose.dev.yml down -v
+docker compose -f docker-compose.staging.yml down
 
 docker compose  -f docker-compose.prod.yml up --build -d --force-recreate
 

--- a/frontend/src/components/Oops.tsx
+++ b/frontend/src/components/Oops.tsx
@@ -1,0 +1,28 @@
+import LogoClientIcon from "./Icons/LogoClient";
+import LogoEntrepriseIcon from "./Icons/LogoEntreprise";
+
+interface propsType {
+  user: string;
+}
+
+export default function Oops({ user }: propsType) {
+  return (
+    <div
+      className={`w-full max-w-72 flex flex-row gap-4 items-center p-4 border rounded-md ${
+        user === "client"
+          ? "bg-orangeBg border-darkorange"
+          : "bg-blueBg border-darkblue "
+      }`}
+    >
+      {user === "client" ? (
+        <LogoEntrepriseIcon className="h-12 w-12 border border-gray-300 rounded-md p-2" />
+      ) : (
+        <LogoClientIcon className="h-12 w-12 border border-gray-300 rounded-md p-2" />
+      )}
+      <div className="">
+        <p className="font-bold">Oops, I am not a {user}</p>
+        <p className="underline text-sm">Click here to Sign Up</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -17,6 +17,7 @@ import Projects from "./pages/Projects";
 import Clients from "./pages/Clients";
 import Settings from "./pages/Settings";
 import Error404visitor from "./pages/Error404";
+import NewAccount from "./pages/NewAccount";
 
 const uriprod = new HttpLink({
   uri: import.meta.env.VITE_GRAPHQL_URI ?? "http://localhost:4000/graphql",
@@ -59,6 +60,14 @@ const router = createBrowserRouter([
       {
         path: "/settings",
         element: <Settings />,
+      },
+      {
+        path: "/newclient",
+        element: <NewAccount user="client" color="bg-blueBg" />,
+      },
+      {
+        path: "/newcompanyuser",
+        element: <NewAccount user="admin" color="bg-orangeBg" />,
       },
       {
         path: "*",

--- a/frontend/src/pages/NewAccount.tsx
+++ b/frontend/src/pages/NewAccount.tsx
@@ -1,0 +1,187 @@
+import { useState, type ChangeEvent, type FormEvent } from "react";
+import LogoClientIcon from "../components/Icons/LogoClient";
+import LogoEntrepriseIcon from "../components/Icons/LogoEntreprise";
+import { gql, useMutation } from "@apollo/client";
+import { Link } from "react-router-dom";
+import Oops from "../components/Oops";
+
+interface PropsType {
+  user: string;
+  color: string;
+}
+
+interface FormData {
+  email: string;
+  name: string;
+  password: string;
+  passwordConfirmation: string;
+}
+
+const CREATE_ACCOUNT_MUTATION = gql`
+  mutation CreateAccount($role: String!, $password: String!, $email: String!) {
+    createAccount(role: $role, password: $password, email: $email) {
+      id
+      email
+      role
+    }
+  }
+`;
+
+export default function NewAccount({ user, color }: PropsType) {
+  const initialFormData: FormData = {
+    email: "",
+    name: "",
+    password: "",
+    passwordConfirmation: "",
+  };
+
+  const [signUpData, setSignUpData] = useState(initialFormData);
+  const [createAccount, { loading, error }] = useMutation(
+    CREATE_ACCOUNT_MUTATION,
+  );
+  const [emailError, setEmailError] = useState("");
+
+  const handleChangeForm = (e: ChangeEvent<HTMLInputElement>) => {
+    setSignUpData((prev) => ({
+      ...prev,
+      [e.target.name]: e.target.value,
+    }));
+  };
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>): Promise<void> => {
+    e.preventDefault();
+    setEmailError(""); // Réinitialise l'erreur à chaque soumission
+
+    if (signUpData.password !== signUpData.passwordConfirmation) {
+      alert("Passwords do not match!");
+      return;
+    }
+
+    try {
+      await createAccount({
+        variables: {
+          email: signUpData.email,
+          password: signUpData.password,
+          role: user.toLowerCase(),
+        },
+      });
+
+      alert("Account successfully created!");
+      setSignUpData(initialFormData); // Réinitialisation du formulaire après succès
+    } catch (err) {
+      console.error("Error creating account:", err);
+
+      // Vérifie si l'erreur vient du backend et concerne l'email
+      if (err instanceof Error && "graphQLErrors" in err) {
+        const graphQLError = err.graphQLErrors.find((error) =>
+          error.message.includes("Email already exists"),
+        );
+
+        if (graphQLError) {
+          setEmailError(graphQLError.message); // Stocke l'erreur pour l'afficher sous l'input email
+          return;
+        }
+      }
+
+      // Autre erreur (erreur serveur, timeout, etc.)
+      alert("Failed to create account! Please try again.");
+    }
+  };
+
+  return (
+    <div
+      className={`px-10 min-h-svh ${color} flex flex-col gap-4 justify-center items-center`}
+    >
+      {user === "admin" ? (
+        <LogoEntrepriseIcon className="h-12 w-12" />
+      ) : (
+        <LogoClientIcon className="h-20 w-20" />
+      )}
+      <h1 className="text-2xl font-bold">
+        CREATE {user.toUpperCase()} ACCOUNT
+      </h1>
+
+      <div className="flex flex-col gap-4 w-full max-w-96">
+        <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+          <label htmlFor="email" className="flex flex-col w-full">
+            Email
+            <input
+              type="email"
+              name="email"
+              value={signUpData.email}
+              placeholder="Email"
+              className="p-2 border border-gray-300 rounded-md w-full"
+              onChange={handleChangeForm}
+              required
+            />
+            {emailError && <p className="text-red-500 text-xs">{emailError}</p>}
+          </label>
+
+          <label htmlFor="name" className="flex flex-col">
+            {`${user} Name`}
+            <input
+              type="text"
+              name="name"
+              value={signUpData.name}
+              placeholder={`${user} Name`}
+              className="p-2 border border-gray-300 rounded-md w-full"
+              onChange={handleChangeForm}
+              required
+            />
+          </label>
+
+          <label htmlFor="password" className="flex flex-col">
+            Password
+            <input
+              type="password"
+              name="password"
+              value={signUpData.password}
+              placeholder="Password"
+              className="p-2 border border-gray-300 rounded-md w-full"
+              onChange={handleChangeForm}
+              required
+            />
+          </label>
+
+          <label htmlFor="passwordConfirmation" className="flex flex-col">
+            Confirm Password
+            <input
+              type="password"
+              name="passwordConfirmation"
+              value={signUpData.passwordConfirmation}
+              placeholder="Confirm Password"
+              className="p-2 border border-gray-300 rounded-md w-full"
+              onChange={handleChangeForm}
+              required
+            />
+          </label>
+
+          <button
+            type="submit"
+            className={`w-56 inline-block rounded-lg py-2 px-4 text-white text-base self-center ${
+              user === "client" ? "bg-bluebase" : "bg-orangebase"
+            }`}
+            disabled={loading}
+          >
+            {loading ? "Signing Up..." : "Sign Up"}
+          </button>
+        </form>
+
+        {error && (
+          <p className="text-red-500 text-sm text-center">
+            Error: {error.message}
+          </p>
+        )}
+
+        <div className="flex flex-row items-center gap-2 justify-center">
+          <p className="text-xs">You already have an account?</p>
+          <Link to="/login" className="font-bold text-xs underline">
+            Sign in
+          </Link>
+        </div>
+      </div>
+
+      <Oops user={user} />
+    </div>
+  );
+}

--- a/frontend/src/pages/NewAccount.tsx
+++ b/frontend/src/pages/NewAccount.tsx
@@ -20,11 +20,18 @@ interface FormData {
 const CREATE_ACCOUNT_MUTATION = gql`
   mutation CreateAccount($role: String!, $password: String!, $email: String!) {
     createAccount(role: $role, password: $password, email: $email) {
-      id
-      email
-      role
+      id   
     }
+  } 
+`;
+
+const CREATE_CLIENT_MUTATION = gql`
+ mutation Mutation($accountId: Float!, $name: String!) {
+  createClient(accountId: $accountId, name: $name) {
+    id
+    name  
   }
+}
 `;
 
 export default function NewAccount({ user, color }: PropsType) {
@@ -39,7 +46,10 @@ export default function NewAccount({ user, color }: PropsType) {
   const [createAccount, { loading, error }] = useMutation(
     CREATE_ACCOUNT_MUTATION,
   );
-  const [emailError, setEmailError] = useState("");
+
+  const [createClient] = useMutation(CREATE_CLIENT_MUTATION);
+
+  const [success, setSuccess] = useState(false);
 
   const handleChangeForm = (e: ChangeEvent<HTMLInputElement>) => {
     setSignUpData((prev) => ({
@@ -50,7 +60,6 @@ export default function NewAccount({ user, color }: PropsType) {
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>): Promise<void> => {
     e.preventDefault();
-    setEmailError(""); // Réinitialise l'erreur à chaque soumission
 
     if (signUpData.password !== signUpData.passwordConfirmation) {
       alert("Passwords do not match!");
@@ -58,42 +67,45 @@ export default function NewAccount({ user, color }: PropsType) {
     }
 
     try {
-      await createAccount({
+      const { data } = await createAccount({
         variables: {
           email: signUpData.email,
           password: signUpData.password,
           role: user.toLowerCase(),
         },
       });
-
-      alert("Account successfully created!");
-      setSignUpData(initialFormData); // Réinitialisation du formulaire après succès
-    } catch (err) {
-      console.error("Error creating account:", err);
-
-      // Vérifie si l'erreur vient du backend et concerne l'email
-      if (err instanceof Error && "graphQLErrors" in err) {
-        const graphQLError = err.graphQLErrors.find((error) =>
-          error.message.includes("Email already exists"),
-        );
-
-        if (graphQLError) {
-          setEmailError(graphQLError.message); // Stocke l'erreur pour l'afficher sous l'input email
-          return;
+      const accountId = Number(data.createAccount.id);
+      if (!accountId) {
+        console.error("No account ID received, aborting client creation.");
+        return;
+      }
+      if (user === "client") {
+        try {
+          await createClient({
+            variables: {
+              name: signUpData.name,
+              accountId: Number(accountId),
+            },
+          });
+          console.log("Client created successfully");
+        } catch (err) {
+          console.error("Error creating client:", err);
         }
       }
 
-      // Autre erreur (erreur serveur, timeout, etc.)
-      alert("Failed to create account! Please try again.");
+      setSuccess(true);
+      setSignUpData(initialFormData);
+    } catch (err) {
+      console.error("Error creating account:", err);
     }
   };
 
   return (
     <div
-      className={`px-10 min-h-svh ${color} flex flex-col gap-4 justify-center items-center`}
+      className={` pt-10 min-h-svh ${color} flex flex-col gap-10 justify-center items-center`}
     >
       {user === "admin" ? (
-        <LogoEntrepriseIcon className="h-12 w-12" />
+        <LogoEntrepriseIcon className="h-20 w-20" />
       ) : (
         <LogoClientIcon className="h-20 w-20" />
       )}
@@ -101,87 +113,106 @@ export default function NewAccount({ user, color }: PropsType) {
         CREATE {user.toUpperCase()} ACCOUNT
       </h1>
 
-      <div className="flex flex-col gap-4 w-full max-w-96">
-        <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
-          <label htmlFor="email" className="flex flex-col w-full">
-            Email
-            <input
-              type="email"
-              name="email"
-              value={signUpData.email}
-              placeholder="Email"
-              className="p-2 border border-gray-300 rounded-md w-full"
-              onChange={handleChangeForm}
-              required
-            />
-            {emailError && <p className="text-red-500 text-xs">{emailError}</p>}
-          </label>
+      <div
+        className={`${user === "admin" ? "bg-orangelight" : "bg-bluelight"} w-full rounded-t-3xl `}
+      >
+        <div
+          className={`${user === "admin" ? "bg-orangelight" : "bg-bluelight"} w-full h-14 rounded-t-[3rem] left-0`}
+        />
 
-          <label htmlFor="name" className="flex flex-col">
-            {`${user} Name`}
-            <input
-              type="text"
-              name="name"
-              value={signUpData.name}
-              placeholder={`${user} Name`}
-              className="p-2 border border-gray-300 rounded-md w-full"
-              onChange={handleChangeForm}
-              required
-            />
-          </label>
+        <div
+          className={`${user === "admin" ? "bg-midorange" : "bg-midblue"} w-full h-14 rounded-t-[3rem] left-0`}
+        />
+        <div className={`${user === "admin" ? "bg-midorange" : "bg-midblue"}`}>
+          <div className="bg-white flex flex-col items-center gap-10 rounded-t-[3rem] py-10">
+            <div className="flex flex-col gap-4  max-w-96 justify-self-center">
+              <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+                <label htmlFor="email" className="flex flex-col w-full">
+                  Email
+                  <input
+                    type="email"
+                    name="email"
+                    value={signUpData.email}
+                    placeholder="Email"
+                    className="p-2 border border-gray-300 rounded-md w-full"
+                    onChange={handleChangeForm}
+                    required
+                  />
+                </label>
 
-          <label htmlFor="password" className="flex flex-col">
-            Password
-            <input
-              type="password"
-              name="password"
-              value={signUpData.password}
-              placeholder="Password"
-              className="p-2 border border-gray-300 rounded-md w-full"
-              onChange={handleChangeForm}
-              required
-            />
-          </label>
+                <label htmlFor="name" className="flex flex-col">
+                  {`${user} Name`}
+                  <input
+                    type="text"
+                    name="name"
+                    value={signUpData.name}
+                    placeholder={`${user} Name`}
+                    className="p-2 border border-gray-300 rounded-md w-full"
+                    onChange={handleChangeForm}
+                    required
+                  />
+                </label>
 
-          <label htmlFor="passwordConfirmation" className="flex flex-col">
-            Confirm Password
-            <input
-              type="password"
-              name="passwordConfirmation"
-              value={signUpData.passwordConfirmation}
-              placeholder="Confirm Password"
-              className="p-2 border border-gray-300 rounded-md w-full"
-              onChange={handleChangeForm}
-              required
-            />
-          </label>
+                <label htmlFor="password" className="flex flex-col">
+                  Password
+                  <input
+                    type="password"
+                    name="password"
+                    value={signUpData.password}
+                    placeholder="Password"
+                    className="p-2 border border-gray-300 rounded-md w-full"
+                    onChange={handleChangeForm}
+                    required
+                  />
+                </label>
 
-          <button
-            type="submit"
-            className={`w-56 inline-block rounded-lg py-2 px-4 text-white text-base self-center ${
-              user === "client" ? "bg-bluebase" : "bg-orangebase"
-            }`}
-            disabled={loading}
-          >
-            {loading ? "Signing Up..." : "Sign Up"}
-          </button>
-        </form>
+                <label htmlFor="passwordConfirmation" className="flex flex-col">
+                  Confirm Password
+                  <input
+                    type="password"
+                    name="passwordConfirmation"
+                    value={signUpData.passwordConfirmation}
+                    placeholder="Confirm Password"
+                    className="p-2 border border-gray-300 rounded-md w-full"
+                    onChange={handleChangeForm}
+                    required
+                  />
+                </label>
 
-        {error && (
-          <p className="text-red-500 text-sm text-center">
-            Error: {error.message}
-          </p>
-        )}
+                <button
+                  type="submit"
+                  className={`w-56 inline-block rounded-lg py-2 px-4 text-white text-base self-center ${
+                    user === "client" ? "bg-bluebase" : "bg-orangebase"
+                  }`}
+                  disabled={loading}
+                >
+                  {loading ? "Signing Up..." : "Sign Up"}
+                </button>
+              </form>
 
-        <div className="flex flex-row items-center gap-2 justify-center">
-          <p className="text-xs">You already have an account?</p>
-          <Link to="/login" className="font-bold text-xs underline">
-            Sign in
-          </Link>
+              {error && (
+                <p className="text-red-500 text-sm text-center">
+                  {error.message}
+                </p>
+              )}
+              {success && (
+                <p className="text-green-700 text-sm text-center">
+                  Account successfully created
+                </p>
+              )}
+
+              <div className="flex flex-row items-center gap-2 justify-center">
+                <p className="text-xs">You already have an account?</p>
+                <Link to="/login" className="font-bold text-xs underline">
+                  Sign in
+                </Link>
+              </div>
+            </div>
+
+            <Oops user={user} />
+          </div>
         </div>
       </div>
-
-      <Oops user={user} />
     </div>
   );
 }

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -2,6 +2,7 @@ import { type ChangeEvent, type FormEvent, useState } from "react";
 import { Link } from "react-router-dom";
 import LogoClientIcon from "../components/Icons/LogoClient";
 import LogoEntrepriseIcon from "../components/Icons/LogoEntreprise";
+import Oops from "../components/Oops";
 
 interface FormData {
   email: string;
@@ -42,7 +43,7 @@ export default function Signup() {
               name="email"
               value={signUpData.email}
               placeholder="Email"
-              className="text-center p-2 border border-gray-300 rounded-md w-full"
+              className=" p-2 border border-gray-300 rounded-md w-full"
               onChange={handleChangeForm}
               required
             />
@@ -54,7 +55,7 @@ export default function Signup() {
               name="accessCode"
               value={signUpData.accessCode}
               placeholder="Code"
-              className="text-center p-2 border border-gray-300 rounded-md w-full"
+              className=" p-2 border border-gray-300 rounded-md w-full"
               onChange={handleChangeForm}
               required
             />


### PR DESCRIPTION
**Création d’un formulaire d’inscription pour les utilisateurs "client" et "admin"**

Fonctionnalités implémentées :
- Création d’un compte utilisateur via une mutation GraphQL createAccount.
-Création d’un client associé (mutation createClient) si le rôle est "client"
-Formulaire contrôlé avec validation des mots de passe.
- Affichage conditionnel du logo et des couleurs selon le type d’utilisateur (admin ou client).
- Gestion des états de succès, d’erreur et de chargement.
