### PR TITLE
add securityRules simpleRateLimiterPlugin for graphql

### DIFF
--- a/backend/src/__tests__/SecurityRules.test.ts
+++ b/backend/src/__tests__/SecurityRules.test.ts
@@ -1,0 +1,179 @@
+import type { ValidationContext } from "graphql";
+import type { FieldNode, OperationDefinitionNode } from "graphql/language/ast";
+import {
+  createComplexityRule,
+  createMaxDepthRule,
+  createNoIntrospectionRule,
+} from "../utils/securityRules";
+
+type ASTVisitorWithOperations = {
+  OperationDefinition?: {
+    enter?: (node: OperationDefinitionNode) => void;
+  };
+  Field?: {
+    enter?: (node: FieldNode) => void;
+  };
+};
+
+describe("Security Rules", () => {
+  describe("MaxDepthRule", () => {
+    const mockContext = {
+      reportError: jest.fn(),
+    } as unknown as ValidationContext;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("should allow queries within depth limit", () => {
+      const maxDepthRule = createMaxDepthRule(2);
+      const rule = maxDepthRule(mockContext) as ASTVisitorWithOperations;
+
+      const mockNode = {
+        selectionSet: {
+          selections: [
+            {
+              selectionSet: {
+                selections: [],
+              },
+            },
+          ],
+        },
+      } as unknown as OperationDefinitionNode;
+
+      rule.OperationDefinition?.enter?.(mockNode);
+      expect(mockContext.reportError).not.toHaveBeenCalled();
+    });
+
+    it("should reject queries exceeding depth limit", () => {
+      const maxDepthRule = createMaxDepthRule(1);
+      const rule = maxDepthRule(mockContext) as ASTVisitorWithOperations;
+
+      const mockNode = {
+        selectionSet: {
+          selections: [
+            {
+              selectionSet: {
+                selections: [
+                  {
+                    selectionSet: {
+                      selections: [],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      } as unknown as OperationDefinitionNode;
+
+      rule.OperationDefinition?.enter?.(mockNode);
+      expect(mockContext.reportError).toHaveBeenCalled();
+    });
+  });
+
+  describe("NoIntrospectionRule", () => {
+    const mockContext = {
+      reportError: jest.fn(),
+    } as unknown as ValidationContext;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("should block introspection queries", () => {
+      const noIntrospectionRule = createNoIntrospectionRule();
+      const rule = noIntrospectionRule(mockContext) as ASTVisitorWithOperations;
+
+      const schemaNode = {
+        kind: "Field",
+        name: {
+          kind: "Name",
+          value: "__schema",
+        },
+      } as unknown as FieldNode;
+
+      const typeNode = {
+        kind: "Field",
+        name: {
+          kind: "Name",
+          value: "__type",
+        },
+      } as unknown as FieldNode;
+
+      rule.Field?.enter?.(schemaNode);
+      expect(mockContext.reportError).toHaveBeenCalledTimes(1);
+
+      jest.clearAllMocks();
+
+      rule.Field?.enter?.(typeNode);
+      expect(mockContext.reportError).toHaveBeenCalledTimes(1);
+    });
+
+    it("should allow normal queries", () => {
+      const noIntrospectionRule = createNoIntrospectionRule();
+      const rule = noIntrospectionRule(mockContext) as ASTVisitorWithOperations;
+
+      const mockNode = {
+        kind: "Field",
+        name: {
+          kind: "Name",
+          value: "normalField",
+        },
+      } as unknown as FieldNode;
+
+      rule.Field?.enter?.(mockNode);
+      expect(mockContext.reportError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("ComplexityRule", () => {
+    const mockContext = {
+      reportError: jest.fn(),
+    } as unknown as ValidationContext;
+
+    it("should calculate query complexity correctly", () => {
+      const complexityRule = createComplexityRule({
+        scalarCost: 1,
+        objectCost: 2,
+        listFactor: 10,
+        maxCost: 100,
+      });
+
+      const rule = complexityRule(mockContext) as ASTVisitorWithOperations;
+
+      const mockNode = {
+        selectionSet: {
+          selections: [
+            { type: { kind: "ListType" } },
+            { type: { kind: "ObjectType" } },
+            {}, // scalar
+          ],
+        },
+      } as unknown as OperationDefinitionNode;
+
+      rule.OperationDefinition?.enter?.(mockNode);
+      expect(mockContext.reportError).not.toHaveBeenCalled();
+    });
+
+    it("should reject queries exceeding complexity limit", () => {
+      const complexityRule = createComplexityRule({
+        scalarCost: 1,
+        objectCost: 2,
+        listFactor: 10,
+        maxCost: 5,
+      });
+
+      const rule = complexityRule(mockContext) as ASTVisitorWithOperations;
+
+      const mockNode = {
+        selectionSet: {
+          selections: Array(10).fill({ type: { kind: "ListType" } }),
+        },
+      } as unknown as OperationDefinitionNode;
+
+      rule.OperationDefinition?.enter?.(mockNode);
+      expect(mockContext.reportError).toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/plugins/simpleRateLimiterPlugin.ts
+++ b/backend/src/plugins/simpleRateLimiterPlugin.ts
@@ -48,7 +48,7 @@ class RateLimiter {
       if (purged > 0) {
         console.log(`[RateLimiter] Purged ${purged} expired entries.`);
       }
-    }, 60_000); // toutes les minutes
+    }, options.windowMs);
   }
 
   getClientIdentifier(requestContext: RequestContext): string {
@@ -91,8 +91,6 @@ export function createRateLimiterPlugin(
 
 return {
   async requestDidStart(requestContext: GraphQLRequestContext<BaseContext>) {
-    //console.log('[RateLimiter] Nouvelle requête à', new Date().toISOString());
-    
     const now = Date.now();
     const identifier = rateLimiter.getClientIdentifier(
       requestContext as RequestContext,
@@ -100,23 +98,24 @@ return {
     const clientInfo = rateLimiter.getRateLimitInfo(identifier, now);
     const { max } = options;
 
-    // D'abord on incrémente le compteur
+      // We increment the counter
     rateLimiter.incrementCount(identifier, clientInfo);
 
-    // et apres on test si la limite est dépassée
-    if (clientInfo.count > max) {
-      console.warn(
-        `[RateLimiter] Client "${identifier}" exceeded the rate limit.`,
-      );
-      throw new GraphQLError(
-        "Trop de requêtes. Veuillez réessayer plus tard.",
-        {
-          extensions: { code: "RATE_LIMITED", http: { status: 429 } },
-        },
-      );
-    }
-
       return {
+        // we test whether the limit has been exceeded
+           async didResolveOperation() {
+          if (clientInfo.count > max) {
+            console.warn(
+              `[RateLimiter] Client "${identifier}" exceeded the rate limit.`,
+            );
+            throw new GraphQLError(
+              "Too many requests. Please try again later.",
+              {
+                extensions: { code: "RATE_LIMITED", http: { status: 429 } },
+              }
+            );
+          }
+        },
         async willSendResponse(responseContext) {
           const remaining = Math.max(0, max - clientInfo.count);
           const resetTime = clientInfo.resetTime;

--- a/backend/src/plugins/simpleRateLimiterPlugin.ts
+++ b/backend/src/plugins/simpleRateLimiterPlugin.ts
@@ -89,29 +89,32 @@ export function createRateLimiterPlugin(
 ): ApolloServerPlugin {
   const rateLimiter = new RateLimiter(options);
 
-  return {
-    async requestDidStart(requestContext: GraphQLRequestContext<BaseContext>) {
-      const now = Date.now();
-      const identifier = rateLimiter.getClientIdentifier(
-        requestContext as RequestContext,
+return {
+  async requestDidStart(requestContext: GraphQLRequestContext<BaseContext>) {
+    //console.log('[RateLimiter] Nouvelle requête à', new Date().toISOString());
+    
+    const now = Date.now();
+    const identifier = rateLimiter.getClientIdentifier(
+      requestContext as RequestContext,
+    );
+    const clientInfo = rateLimiter.getRateLimitInfo(identifier, now);
+    const { max } = options;
+
+    // D'abord on incrémente le compteur
+    rateLimiter.incrementCount(identifier, clientInfo);
+
+    // et apres on test si la limite est dépassée
+    if (clientInfo.count > max) {
+      console.warn(
+        `[RateLimiter] Client "${identifier}" exceeded the rate limit.`,
       );
-      const clientInfo = rateLimiter.getRateLimitInfo(identifier, now);
-      const { max } = options;
-
-      // Check if client exceeds limit
-      if (clientInfo.count > max) {
-        console.warn(
-          `[RateLimiter] Client "${identifier}" exceeded the rate limit.`,
-        );
-        throw new GraphQLError(
-          "Trop de requêtes. Veuillez réessayer plus tard.",
-          {
-            extensions: { code: "RATE_LIMITED", http: { status: 429 } },
-          },
-        );
-      }
-
-      rateLimiter.incrementCount(identifier, clientInfo);
+      throw new GraphQLError(
+        "Trop de requêtes. Veuillez réessayer plus tard.",
+        {
+          extensions: { code: "RATE_LIMITED", http: { status: 429 } },
+        },
+      );
+    }
 
       return {
         async willSendResponse(responseContext) {

--- a/backend/src/plugins/simpleRateLimiterPlugin.ts
+++ b/backend/src/plugins/simpleRateLimiterPlugin.ts
@@ -1,0 +1,138 @@
+import type {
+  ApolloServerPlugin,
+  BaseContext,
+  GraphQLRequestContext,
+} from "@apollo/server";
+import { GraphQLError } from "graphql";
+
+interface RateLimitOptions {
+  windowMs: number;
+  max: number;
+}
+
+interface RateLimitInfo {
+  count: number;
+  resetTime: number;
+}
+
+interface RequestContext {
+  request: {
+    http?: {
+      headers: {
+        get(name: string): string | null;
+      };
+    };
+  };
+  contextValue: {
+    req?: {
+      ip?: string;
+    };
+  };
+}
+
+// Create a class to manage rate limiting
+class RateLimiter {
+  private rateLimitMap = new Map<string, RateLimitInfo>();
+  private purgeInterval: NodeJS.Timeout;
+
+  constructor(private options: RateLimitOptions) {
+    this.purgeInterval = setInterval(() => {
+      const now = Date.now();
+      let purged = 0;
+      for (const [identifier, info] of this.rateLimitMap) {
+        if (info.resetTime < now) {
+          this.rateLimitMap.delete(identifier);
+          purged++;
+        }
+      }
+      if (purged > 0) {
+        console.log(`[RateLimiter] Purged ${purged} expired entries.`);
+      }
+    }, 60_000); // toutes les minutes
+  }
+
+  getClientIdentifier(requestContext: RequestContext): string {
+    const authHeader =
+      requestContext.request.http?.headers.get("authorization") || "";
+    if (authHeader.startsWith("Bearer ")) {
+      return authHeader.substring(7); // Remove 'Bearer ' prefix
+    }
+    return requestContext.contextValue.req?.ip || "anonymous";
+  }
+
+  getRateLimitInfo(identifier: string, now: number): RateLimitInfo {
+    const info = this.rateLimitMap.get(identifier);
+    if (!info || info.resetTime < now) {
+      console.log(`[RateLimiter] New window for client "${identifier}".`);
+      const newInfo = { count: 0, resetTime: now + this.options.windowMs };
+      this.rateLimitMap.set(identifier, newInfo);
+      return newInfo;
+    }
+    return info;
+  }
+
+  incrementCount(identifier: string, info: RateLimitInfo): void {
+    info.count++;
+    console.log(
+      `[RateLimiter] Client "${identifier}" has now made ${info.count} requests.`,
+    );
+  }
+
+  cleanup(): void {
+    clearInterval(this.purgeInterval);
+    this.rateLimitMap.clear();
+  }
+}
+
+export function createRateLimiterPlugin(
+  options: RateLimitOptions,
+): ApolloServerPlugin {
+  const rateLimiter = new RateLimiter(options);
+
+  return {
+    async requestDidStart(requestContext: GraphQLRequestContext<BaseContext>) {
+      const now = Date.now();
+      const identifier = rateLimiter.getClientIdentifier(
+        requestContext as RequestContext,
+      );
+      const clientInfo = rateLimiter.getRateLimitInfo(identifier, now);
+      const { max } = options;
+
+      // Check if client exceeds limit
+      if (clientInfo.count > max) {
+        console.warn(
+          `[RateLimiter] Client "${identifier}" exceeded the rate limit.`,
+        );
+        throw new GraphQLError(
+          "Trop de requêtes. Veuillez réessayer plus tard.",
+          {
+            extensions: { code: "RATE_LIMITED", http: { status: 429 } },
+          },
+        );
+      }
+
+      rateLimiter.incrementCount(identifier, clientInfo);
+
+      return {
+        async willSendResponse(responseContext) {
+          const remaining = Math.max(0, max - clientInfo.count);
+          const resetTime = clientInfo.resetTime;
+          const resetTimeSeconds = Math.ceil((resetTime - now) / 1000);
+
+          responseContext.response.http?.headers.set(
+            "X-RateLimit-Limit",
+            max.toString(),
+          );
+          responseContext.response.http?.headers.set(
+            "X-RateLimit-Remaining",
+            remaining.toString(),
+          );
+          responseContext.response.http?.headers.set(
+            "X-RateLimit-Reset",
+            resetTimeSeconds.toString(),
+          );
+        },
+      };
+    },
+  };
+}

--- a/backend/src/startApollo.ts
+++ b/backend/src/startApollo.ts
@@ -1,33 +1,39 @@
 import "reflect-metadata";
 import { ApolloServer } from "@apollo/server";
 import { startStandaloneServer } from "@apollo/server/standalone";
-import { dataSource } from "./dataSource/dataSource";
-import { ProjectQueries } from "./graphql-resolvers/ProjectQueries";
 import { buildSchema } from "type-graphql";
 import { registerEnumType } from "type-graphql";
-import { Role } from "./enums/Role";
-import { ProjectStatus } from "./enums/ProjectStatus";
+import { dataSource } from "./dataSource/dataSource";
+// import { initTestData } from "./scripts/initTestData";
+import { Project } from "./entities/Project";
 import { AccountStatus } from "./enums/AccountStatus";
-import { ProjectMutations } from "./graphql-resolvers/ProjectMutations";
-import { CompagnyQueries } from "./graphql-resolvers/CompagnyQueries";
-import { CompagnyMutations } from "./graphql-resolvers/CompagnyMutations";
-import { TaskQueries } from "./graphql-resolvers/TaskQueries";
-import { TaskMutations } from "./graphql-resolvers/TaskMutations";
-import { DeliverableQueries } from "./graphql-resolvers/DeliverableQueries";
-import { DeliverableMutations } from "./graphql-resolvers/DeliverableMutations";
-import { ClientQueries } from "./graphql-resolvers/ClientQueries";
-import { ClientMutations } from "./graphql-resolvers/ClientMutations";
+import { ClientStatus } from "./enums/ClientStatus";
+import { ProjectStatus } from "./enums/ProjectStatus";
+import { Role } from "./enums/Role";
 import {
   AccountMutation,
   AuthMutation,
 } from "./graphql-resolvers/AccountMutation";
 import { AccountQueries } from "./graphql-resolvers/AccountQueries";
-import type { MyContext } from "./types/MyContext";
-// import { initTestData } from "./scripts/initTestData";
-import { Project } from "./entities/Project";
-import { authChecker, getAccount } from "./middlewares/auth";
-import { ClientStatus } from "./enums/ClientStatus";
+import { ClientMutations } from "./graphql-resolvers/ClientMutations";
+import { ClientQueries } from "./graphql-resolvers/ClientQueries";
+import { CompagnyMutations } from "./graphql-resolvers/CompagnyMutations";
+import { CompagnyQueries } from "./graphql-resolvers/CompagnyQueries";
+import { DeliverableMutations } from "./graphql-resolvers/DeliverableMutations";
+import { DeliverableQueries } from "./graphql-resolvers/DeliverableQueries";
+import { ProjectMutations } from "./graphql-resolvers/ProjectMutations";
+import { ProjectQueries } from "./graphql-resolvers/ProjectQueries";
+import { TaskMutations } from "./graphql-resolvers/TaskMutations";
+import { TaskQueries } from "./graphql-resolvers/TaskQueries";
 import { TrackerStatsQueries } from "./graphql-resolvers/TrackerStatsQueries";
+import { authChecker, getAccount } from "./middlewares/auth";
+import { createRateLimiterPlugin } from "./plugins/simpleRateLimiterPlugin";
+import type { MyContext } from "./types/MyContext";
+import {
+  createComplexityRule,
+  createMaxDepthRule,
+  createNoIntrospectionRule,
+} from './utils/securityRules';
 
 registerEnumType(Role, {
   name: "Role",
@@ -78,7 +84,31 @@ async function startServerApollo() {
       ],
       authChecker,
     });
-    const server = new ApolloServer<MyContext>({ schema });
+    const server = new ApolloServer<MyContext>({ 
+      schema, // Autorise l’introspection en dehors de la prod
+      introspection: process.env.NODE_ENV !== 'production', 
+      // règles de validation
+      validationRules: [
+        createMaxDepthRule(10),              // profondeurs max = 10
+        createComplexityRule({               // complexité max = 1000
+        scalarCost: 1,
+        objectCost: 2,
+        listFactor: 10,
+        maxCost: 1000,
+    }),
+    // Désactive l’introspection en prod
+    ...(process.env.NODE_ENV === 'production'
+      ? [createNoIntrospectionRule()]
+      : []),
+  ],
+  // plugins — on y met notre rate-limiter in-memory
+  plugins: [
+    createRateLimiterPlugin({
+      windowMs: 60_000, // 1 minute
+      max: 100,         // 100 requêtes max par fenêtre
+    }),
+  ],
+});
 
     await dataSource.initialize();
     console.info("Data Source has been initialized!");
@@ -93,7 +123,7 @@ async function startServerApollo() {
         // Try to retrieve a user with the token
         const user = await getAccount(token);
 
-        // // Add the user to the context
+        // Add the user to the context
         return { user };
       },
       listen: { port, host: "0.0.0.0" },
@@ -102,6 +132,7 @@ async function startServerApollo() {
     console.info(`🚀  Server ready at: ${url}`);
   } catch (error) {
     console.error("Error starting server:", error);
+    process.exit(1); // Quitter en cas d'erreur critique
   }
 }
 

--- a/backend/src/startApollo.ts
+++ b/backend/src/startApollo.ts
@@ -85,27 +85,27 @@ async function startServerApollo() {
       authChecker,
     });
     const server = new ApolloServer<MyContext>({ 
-      schema, // Autorise l’introspection en dehors de la prod
+      schema, // Allows introspection outside of the prod
       introspection: process.env.NODE_ENV !== 'production', 
       // règles de validation
       validationRules: [
-        createMaxDepthRule(10),              // profondeurs max = 10
-        createComplexityRule({               // complexité max = 1000
+        createMaxDepthRule(10),              // max depth = 10
+        createComplexityRule({               // max complexity = 1000
         scalarCost: 1,
         objectCost: 2,
         listFactor: 10,
         maxCost: 1000,
     }),
-    // Désactive l’introspection en prod
+    // Disable introspection in prod
     ...(process.env.NODE_ENV === 'production'
       ? [createNoIntrospectionRule()]
       : []),
   ],
-  // plugins — on y met notre rate-limiter in-memory
+  // we put our rate-limiter in-memory
   plugins: [
     createRateLimiterPlugin({
       windowMs: 60_000, // 1 minute
-      max: 100,         // 100 requêtes max par fenêtre
+      max: 100,         // 100 requests per minute
     }),
   ],
 });
@@ -132,7 +132,7 @@ async function startServerApollo() {
     console.info(`🚀  Server ready at: ${url}`);
   } catch (error) {
     console.error("Error starting server:", error);
-    process.exit(1); // Quitter en cas d'erreur critique
+    process.exit(1); // Quit on a critical error
   }
 }
 

--- a/backend/src/utils/securityRules.ts
+++ b/backend/src/utils/securityRules.ts
@@ -1,0 +1,99 @@
+import type { ASTVisitor, ValidationContext } from "graphql";
+import { GraphQLError } from "graphql";
+import type {
+  FieldNode,
+  InlineFragmentNode,
+  OperationDefinitionNode,
+} from "graphql/language/ast";
+
+interface ComplexityConfig {
+  scalarCost: number;
+  objectCost: number;
+  listFactor: number;
+  maxCost: number;
+}
+
+export function createMaxDepthRule(maxDepth: number) {
+  return (context: ValidationContext): ASTVisitor => ({
+    OperationDefinition: {
+      enter(node: OperationDefinitionNode) {
+        const depth = calculateDepth(node);
+        if (depth > maxDepth) {
+          context.reportError(
+            new GraphQLError(
+              `Query exceeds maximum depth of ${maxDepth}. Current depth: ${depth}`,
+              { nodes: [node] },
+            ),
+          );
+        }
+      },
+    },
+  });
+}
+
+export function createNoIntrospectionRule() {
+  return (context: ValidationContext): ASTVisitor => ({
+    Field: {
+      enter(node: FieldNode) {
+        if (node.name.value === "__schema" || node.name.value === "__type") {
+          context.reportError(
+            new GraphQLError("Introspection queries are not allowed", {
+              nodes: [node],
+            }),
+          );
+        }
+      },
+    },
+  });
+}
+
+export function createComplexityRule(config: ComplexityConfig) {
+  return (context: ValidationContext): ASTVisitor => ({
+    OperationDefinition: {
+      enter(node: OperationDefinitionNode) {
+        const complexity = calculateComplexity(node, config);
+        if (complexity > config.maxCost) {
+          context.reportError(
+            new GraphQLError(
+              `Query exceeds maximum complexity of ${config.maxCost}. Current complexity: ${complexity}`,
+              { nodes: [node] },
+            ),
+          );
+        }
+      },
+    },
+  });
+}
+
+function calculateDepth(
+  node: OperationDefinitionNode | FieldNode | InlineFragmentNode,
+): number {
+  if (!node.selectionSet) return 0;
+
+  let maxDepth = 0;
+  for (const selection of node.selectionSet.selections) {
+    if ("selectionSet" in selection) {
+      const depth = calculateDepth(selection);
+      maxDepth = Math.max(maxDepth, depth);
+    }
+  }
+  return maxDepth + 1;
+}
+
+function calculateComplexity(
+  node: OperationDefinitionNode | FieldNode | InlineFragmentNode,
+  config: ComplexityConfig,
+): number {
+  if (!node.selectionSet) return config.scalarCost;
+
+  let complexity = 0;
+  for (const selection of node.selectionSet.selections) {
+    if ("selectionSet" in selection) {
+      complexity += config.objectCost;
+      complexity += calculateComplexity(selection, config);
+    } else {
+      complexity += config.scalarCost;
+    }
+  }
+  return complexity;
+}

--- a/backend/src/utils/securityRules.ts
+++ b/backend/src/utils/securityRules.ts
@@ -1,4 +1,4 @@
-import type { ASTVisitor, ValidationContext } from "graphql";
+import type { ASTVisitor, ValidationContext, ValidationRule } from "graphql";
 import { GraphQLError } from "graphql";
 import type {
   FieldNode,
@@ -13,7 +13,7 @@ interface ComplexityConfig {
   maxCost: number;
 }
 
-export function createMaxDepthRule(maxDepth: number) {
+export function createMaxDepthRule(maxDepth: number): ValidationRule {
   return (context: ValidationContext): ASTVisitor => ({
     OperationDefinition: {
       enter(node: OperationDefinitionNode) {
@@ -31,7 +31,7 @@ export function createMaxDepthRule(maxDepth: number) {
   });
 }
 
-export function createNoIntrospectionRule() {
+export function createNoIntrospectionRule(): ValidationRule {
   return (context: ValidationContext): ASTVisitor => ({
     Field: {
       enter(node: FieldNode) {
@@ -47,7 +47,7 @@ export function createNoIntrospectionRule() {
   });
 }
 
-export function createComplexityRule(config: ComplexityConfig) {
+export function createComplexityRule(config: ComplexityConfig): ValidationRule {
   return (context: ValidationContext): ASTVisitor => ({
     OperationDefinition: {
       enter(node: OperationDefinitionNode) {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,12 +18,15 @@ services:
     volumes:
       - ./backend:/app
       - /app/node_modules
+    env_file:
+      - .env  
     environment:
       DB_HOST: ${DB_HOST}
       DB_PORT: ${DB_PORT}
       DB_NAME: ${DB_NAME}
       DB_USER: ${DB_USER}
       DB_PASSWORD: ${DB_PASSWORD}
+      NODE_ENV: development
 
   db:
     image: postgres:16

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - web-client-build:/app/dist
     environment:
-      - NODE_ENV=production  
+      NODE_ENV: production  
 
   backend:
     # build: ./backend
@@ -18,14 +18,15 @@ services:
     command: sh -c "npm run build && npm run prod"
     expose:
       - 4000
+    env_file:
+      - .env      
     environment:
-      - NODE_ENV=production
-      - SERVER_PORT=4000
-      - DB_HOST=${DB_HOST}
-      - DB_PORT=${DB_PORT}
-      - DB_NAME=${DB_NAME}
-      - DB_USER=${DB_USER}
-      - DB_PASSWORD=${DB_PASSWORD}
+      NODE_ENV: production
+      DB_HOST: ${DB_HOST}
+      DB_PORT: ${DB_PORT}
+      DB_NAME: ${DB_NAME}
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
     depends_on:
       - db
 

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -9,8 +9,10 @@ services:
     restart: unless-stopped
     volumes:
       - web-client-build:/app/dist
+    env_file:
+      - .env
     environment:
-      - NODE_ENV=production
+      NODE_ENV: staging 
    
     # restart: always
   backend:
@@ -24,7 +26,9 @@ services:
     depends_on:
       - db
     env_file : 
-    - .env   
+      - .env
+    environment:
+      NODE_ENV: staging
  
 
   db:


### PR DESCRIPTION

## Contexte et Objectif

Pour renforcer la sécurité de notre API GraphQL, cette PR introduit trois grands volets :

1. **`simpleRateLimiterPlugin`** : un plugin Apollo Server qui limite le nombre de requêtes par fenêtre de temps, identifie les clients par token ou IP, et purge automatiquement les compteurs expirés.
2. **`securityRules`** : un ensemble de règles de validation GraphQL pour :

   * limiter la profondeur maximale des requêtes (`MaxDepth`)
   * désactiver l’introspection (`NoIntrospection`)
   * contrôler la « complexité » des requêtes (`ComplexityRule`)
3. **Mise à jour des environnements Docker** : adaptation des fichiers `docker-compose.yml` pour dev, staging et prod afin de désactiver l’introspection en production et en staging, et de l’activer uniquement en développement si besoin.

---

## Détails de l’implémentation

### 1. Plugin de Rate Limiting (`simpleRateLimiterPlugin`)

* **Options configurables**

  * `windowMs` : durée de la fenêtre (en ms)
  * `max` : nombre maximal de requêtes autorisées par client
* **Identifier le client**

  * Priorité : jeton Bearer → en-tête `x-forwarded-for` → `req.ip` → `anonymous`
* **Stockage en mémoire**

  * `Map<string, { count, resetTime }>`
  * Purge des entrées expirées toutes les minutes, avec log du nombre de suppressions
* **Comportement**

  * À chaque requête : incrément du compteur, throw d’une `GraphQLError(code: RATE_LIMITED, status: 429)` si le client dépasse `max`
  * En réponse : ajout des headers `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`

### 2. Règles de sécurité GraphQL (`securityRules`)

* **`createMaxDepthRule(maxDepth)`**

  * Parcourt récursivement chaque niveau de sélection
  * Erreur `Max depth {maxDepth} exceeded ({depth})` si on dépasse la profondeur
* **`createNoIntrospectionRule()`**

  * Bloque toute requête contenant les champs `__schema` ou `__type`
  * Erreur `Introspection disabled`
* **`createComplexityRule(opts)`**

  * Calcule un coût cumulatif basé sur :

    * `scalarCost` pour les champs sans sous-sélections
    * `objectCost` pour les objets
    * `listFactor` si le type est une liste
  * Arrête et signale `Cost {cost} exceeds max {opts.maxCost}` dès que le coût dépasse la limite

### 3. Mise à jour des environnements Docker

* **`docker-compose.dev.yml`**

  * Autorise l’introspection par défaut pour le développement local
* **`docker-compose.staging.yml` & `docker-compose.prod.yml`**

  * Ajout d’une variable d’environnement `GRAPHQL_INTROSPECTION=false`
  * Configuration du démarrage du serveur pour installer `createNoIntrospectionRule` si cette variable est à `false`

il faudra mettre a jour la doc 

  * Expliquer l’usage de `createRateLimiterPlugin` et ses options
  * Décrire les règles de validation et l’activation via la variable `GRAPHQL_INTROSPECTION`

