### PR TITLE
fix: make client field nullable in Account entity

### DIFF
--- a/backend/src/entities/Account.ts
+++ b/backend/src/entities/Account.ts
@@ -42,9 +42,12 @@ export class Account extends BaseEntity {
   @OneToOne(
     () => Client,
     (client) => client.account,
+    {
+      nullable: true,
+    },
   )
-  @Field(() => Client)
-  client!: Client;
+  @Field(() => Client, { nullable: true })
+  client?: Client;
 
   @OneToOne(
     () => CompanyUser,


### PR DESCRIPTION
# Make Account.client field nullable

## Description
Cette PR résout le bug "Error: Cannot return null for non-nullable field Account.client" en rendant le champ `client` nullable dans l'entité `Account`.

## Changements
- Modification de la relation `@OneToOne` avec `Client` dans `Account.ts` pour la rendre nullable
- Ajout de l'option `nullable: true` dans les décorateurs TypeORM et GraphQL
- Mise à jour du type TypeScript pour refléter la nullabilité

## Impact
- Résout l'erreur GraphQL lors de l'accès aux settings lorsqu'un companyUser est connecté (sans client associé)
- Maintient la cohérence des types avec le schéma GraphQL

## Tests
- [x] Vérification que la page Settings charge correctement
- [x] Vérification que les comptes sans client sont correctement gérés
- [x] Vérification que les comptes avec client continuent de fonctionner normalement

## Notes techniques
- Utilisation de `synchronize: true` de TypeORM pour la mise à jour automatique de la base de données
- Régénération des types GraphQL avec codegen