### PR TITLE
fix/accountId-type-to-String-for-UUID-compatibility

### DIFF
--- a/frontend/src/graphql-mutations/client.ts
+++ b/frontend/src/graphql-mutations/client.ts
@@ -1,7 +1,7 @@
 import { gql } from "@apollo/client";
 
 export const CREATE_CLIENT_MUTATION = gql`
- mutation Mutation($accountId: Float!, $name: String!) {
+ mutation Mutation($accountId: String!, $name: String!) {
   createClient(accountId: $accountId, Name: $name) {
     id
     clientName
@@ -24,6 +24,7 @@ export const ARCHIVE_CLIENT_MUTATION = gql`
     }
   }
 `;
+
 export const UPDATE_CLIENT_MUTATION = gql`
   mutation UpdateClient(
     $id: Float!,


### PR DESCRIPTION
suite à l erreur de type détecté : 

Generate outputs
  ❯ Generate to ./src/__generated__/graphql-types.ts
    ✔ Load GraphQL schemas
    ✔ Load GraphQL documents
    ✖ GraphQL Document Validation failed with 1 errors;
      Error 0: Variable "$accountId" of type "Float!" used in position expecting type "String…
      
Correction : mise à jour du type accountId de Float à String dans les mutations client

- Modification du type accountId dans CREATE_CLIENT_MUTATION pour correspondre au schéma backend
- Garantit la compatibilité avec l'implémentation UUID

    