### PR TITLE
Biome ignore codegen

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "ignore": []
+    "ignore": ["frontend/src/__generated__/*"]
   },
 
   "formatter": {

--- a/biome.json
+++ b/biome.json
@@ -7,14 +7,14 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "ignore": ["frontend/src/__generated__/*"]
+    "ignore": ["frontend/src/__generated__/**"]
   },
 
   "formatter": {
     "enabled": true,
     "indentStyle": "space",
     "formatWithErrors": false,
-    "ignore": [],
+    "ignore": ["frontend/src/__generated__/**"],
     "attributePosition": "auto",
     "indentWidth": 2,
     "lineWidth": 80,


### PR DESCRIPTION
Mise à jour de Biome : 
Il ignore tout le dossier frontend/src/__generated__/ pour le lint et le formatage, y compris les sous-dossiers.