### PR TITLE
Update/edit and delete project

### DIFF
--- a/backend/src/graphql-resolvers/ProjectMutations.ts
+++ b/backend/src/graphql-resolvers/ProjectMutations.ts
@@ -15,6 +15,7 @@ import { generateActivationToken } from "../utils/accesstoken";
 import { sendActivationEmail } from "../services/sendActivationEmail";
 import { invalidateCache } from "../utils/invalidatecache";
 import { ClientStatus } from "../enums/ClientStatus";
+import { UpdateProjectInput } from "../inputs/UpdateProjectInput";
 
 @Resolver(Project)
 export class ProjectMutations {
@@ -240,5 +241,28 @@ export class ProjectMutations {
     }
 
     return result.newproject;
+  }
+
+  @Mutation(() => Project)
+  async updateProject(
+    @Arg("data", () => UpdateProjectInput) data: UpdateProjectInput,
+  ): Promise<Project> {
+    const project = await dataSource.manager.findOne(Project, {
+      where: { id: data.id },
+    });
+    console.info("data dans back", data);
+    console.info("projet dans back ", project);
+    if (!project) {
+      throw new Error("Unable to find the project");
+    }
+    if (data.name !== undefined) {
+      project.projectName = data.name;
+    }
+    if (data.description !== undefined) {
+      project.description = data.description;
+    }
+    if (data.endDate !== undefined) project.endDate = data.endDate;
+    await dataSource.manager.save(project);
+    return project;
   }
 }

--- a/backend/src/graphql-resolvers/ProjectMutations.ts
+++ b/backend/src/graphql-resolvers/ProjectMutations.ts
@@ -243,6 +243,7 @@ export class ProjectMutations {
     return result.newproject;
   }
 
+  @Authorized("ADMIN")
   @Mutation(() => Project)
   async updateProject(
     @Arg("data", () => UpdateProjectInput) data: UpdateProjectInput,
@@ -264,5 +265,65 @@ export class ProjectMutations {
     if (data.endDate !== undefined) project.endDate = data.endDate;
     await dataSource.manager.save(project);
     return project;
+  }
+
+  @Authorized("ADMIN")
+  @Mutation(() => Boolean)
+  async deleteProject(
+    @Arg("projectId", () => Number) projectId: number,
+  ): Promise<boolean> {
+    try {
+      const project = await dataSource.manager.findOne(Project, {
+        where: { id: projectId },
+        relations: ["client", "client.account"],
+      });
+
+      if (!project) {
+        throw new GraphQLError(`Project with ID ${projectId} not found`, {
+          extensions: { code: "PROJECT_NOT_FOUND" },
+        });
+      }
+
+      const client = project.client;
+      console.info("client dans delete", client);
+
+      if (!client) {
+        throw new GraphQLError(
+          `Le projet ${projectId} n'est associé à aucun client.`,
+          {
+            extensions: { code: "CLIENT_NOT_FOUND" },
+          },
+        );
+      }
+
+      await dataSource.manager.remove(project);
+
+      // On check si le client a encore des projets ,
+      // si non on passe le statut du client en INACTIVE et le account en INACTIVE
+      const remainingProjects = await dataSource.manager.count(Project, {
+        where: { client: { id: client.id } },
+      });
+
+      if (remainingProjects === 0) {
+        client.status = ClientStatus.INACTIVE;
+
+        if (client.account) {
+          client.account.status = AccountStatus.INACTIVE;
+          await dataSource.manager.save(client.account);
+        }
+
+        await dataSource.manager.save(client);
+        console.info(`Client ${client.id} et son compte ont été désactivés`);
+      }
+
+      return true;
+    } catch (error) {
+      throw new GraphQLError("Failed to delete project", {
+        extensions: {
+          code: "DELETE_PROJECT_ERROR",
+          originalError: (error as Error).message || "Unknown error",
+        },
+      });
+    }
   }
 }

--- a/backend/src/inputs/UpdateProjectInput.ts
+++ b/backend/src/inputs/UpdateProjectInput.ts
@@ -1,0 +1,25 @@
+import { IsNotEmpty, IsOptional, IsString } from "class-validator";
+import { InputType, Field, ID } from "type-graphql";
+
+@InputType()
+export class UpdateProjectInput {
+  @Field(() => ID)
+  id!: number;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  name?: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  description?: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsNotEmpty()
+  endDate?: string;
+}

--- a/frontend/src/__generated__/graphql-types.ts
+++ b/frontend/src/__generated__/graphql-types.ts
@@ -139,6 +139,7 @@ export type Mutation = {
   updateCompany: Company;
   updateDeliverable: Deliverable;
   updatePassword: Scalars['Boolean']['output'];
+  updateProject: Project;
   updateTask: Task;
 };
 
@@ -245,6 +246,11 @@ export type MutationUpdateDeliverableArgs = {
 export type MutationUpdatePasswordArgs = {
   currentPassword: Scalars['String']['input'];
   newPassword: Scalars['String']['input'];
+};
+
+
+export type MutationUpdateProjectArgs = {
+  data: UpdateProjectInput;
 };
 
 
@@ -361,6 +367,13 @@ export type UpdateDeliverableInput = {
   status?: InputMaybe<DeliverableStatus>;
 };
 
+export type UpdateProjectInput = {
+  description?: InputMaybe<Scalars['String']['input']>;
+  endDate?: InputMaybe<Scalars['String']['input']>;
+  id: Scalars['ID']['input'];
+  name?: InputMaybe<Scalars['String']['input']>;
+};
+
 export type UpdateTaskInput = {
   deliverableId?: InputMaybe<Scalars['Float']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
@@ -425,13 +438,6 @@ export type UpdateClientMutationVariables = Exact<{
 
 export type UpdateClientMutation = { __typename?: 'Mutation', updateClient: { __typename?: 'Client', id: string, clientName?: string | null, status?: ClientStatus | null, account?: { __typename?: 'Account', email: string } | null } };
 
-export type CreateProjectMutationVariables = Exact<{
-  newProject: CreateProjectInput;
-}>;
-
-
-export type CreateProjectMutation = { __typename?: 'Mutation', createProject: { __typename?: 'Project', id: string, projectName: string, companyUserId: number, description?: string | null, startDate?: string | null, endDate?: string | null, status?: ProjectStatus | null } };
-
 export type DeleteDeliverableMutationVariables = Exact<{
   id: Scalars['Float']['input'];
 }>;
@@ -461,6 +467,20 @@ export type LoginMutationVariables = Exact<{
 
 
 export type LoginMutation = { __typename?: 'Mutation', login: string };
+
+export type CreateProjectMutationVariables = Exact<{
+  newProject: CreateProjectInput;
+}>;
+
+
+export type CreateProjectMutation = { __typename?: 'Mutation', createProject: { __typename?: 'Project', id: string, projectName: string, companyUserId: number, description?: string | null, startDate?: string | null, endDate?: string | null, status?: ProjectStatus | null } };
+
+export type UpdateProjectMutationVariables = Exact<{
+  data: UpdateProjectInput;
+}>;
+
+
+export type UpdateProjectMutation = { __typename?: 'Mutation', updateProject: { __typename?: 'Project', id: string, projectName: string, description?: string | null, endDate?: string | null } };
 
 export type DeleteTaskMutationVariables = Exact<{
   id: Scalars['Float']['input'];
@@ -799,45 +819,6 @@ export function useUpdateClientMutation(baseOptions?: Apollo.MutationHookOptions
 export type UpdateClientMutationHookResult = ReturnType<typeof useUpdateClientMutation>;
 export type UpdateClientMutationResult = Apollo.MutationResult<UpdateClientMutation>;
 export type UpdateClientMutationOptions = Apollo.BaseMutationOptions<UpdateClientMutation, UpdateClientMutationVariables>;
-export const CreateProjectDocument = gql`
-    mutation CreateProject($newProject: CreateProjectInput!) {
-  createProject(newProject: $newProject) {
-    id
-    projectName
-    companyUserId
-    description
-    startDate
-    endDate
-    status
-  }
-}
-    `;
-export type CreateProjectMutationFn = Apollo.MutationFunction<CreateProjectMutation, CreateProjectMutationVariables>;
-
-/**
- * __useCreateProjectMutation__
- *
- * To run a mutation, you first call `useCreateProjectMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useCreateProjectMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [createProjectMutation, { data, loading, error }] = useCreateProjectMutation({
- *   variables: {
- *      newProject: // value for 'newProject'
- *   },
- * });
- */
-export function useCreateProjectMutation(baseOptions?: Apollo.MutationHookOptions<CreateProjectMutation, CreateProjectMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<CreateProjectMutation, CreateProjectMutationVariables>(CreateProjectDocument, options);
-      }
-export type CreateProjectMutationHookResult = ReturnType<typeof useCreateProjectMutation>;
-export type CreateProjectMutationResult = Apollo.MutationResult<CreateProjectMutation>;
-export type CreateProjectMutationOptions = Apollo.BaseMutationOptions<CreateProjectMutation, CreateProjectMutationVariables>;
 export const DeleteDeliverableDocument = gql`
     mutation DeleteDeliverable($id: Float!) {
   deleteDeliverable(id: $id)
@@ -988,6 +969,81 @@ export function useLoginMutation(baseOptions?: Apollo.MutationHookOptions<LoginM
 export type LoginMutationHookResult = ReturnType<typeof useLoginMutation>;
 export type LoginMutationResult = Apollo.MutationResult<LoginMutation>;
 export type LoginMutationOptions = Apollo.BaseMutationOptions<LoginMutation, LoginMutationVariables>;
+export const CreateProjectDocument = gql`
+    mutation CreateProject($newProject: CreateProjectInput!) {
+  createProject(newProject: $newProject) {
+    id
+    projectName
+    companyUserId
+    description
+    startDate
+    endDate
+    status
+  }
+}
+    `;
+export type CreateProjectMutationFn = Apollo.MutationFunction<CreateProjectMutation, CreateProjectMutationVariables>;
+
+/**
+ * __useCreateProjectMutation__
+ *
+ * To run a mutation, you first call `useCreateProjectMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateProjectMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createProjectMutation, { data, loading, error }] = useCreateProjectMutation({
+ *   variables: {
+ *      newProject: // value for 'newProject'
+ *   },
+ * });
+ */
+export function useCreateProjectMutation(baseOptions?: Apollo.MutationHookOptions<CreateProjectMutation, CreateProjectMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateProjectMutation, CreateProjectMutationVariables>(CreateProjectDocument, options);
+      }
+export type CreateProjectMutationHookResult = ReturnType<typeof useCreateProjectMutation>;
+export type CreateProjectMutationResult = Apollo.MutationResult<CreateProjectMutation>;
+export type CreateProjectMutationOptions = Apollo.BaseMutationOptions<CreateProjectMutation, CreateProjectMutationVariables>;
+export const UpdateProjectDocument = gql`
+    mutation UpdateProject($data: UpdateProjectInput!) {
+  updateProject(data: $data) {
+    id
+    projectName
+    description
+    endDate
+  }
+}
+    `;
+export type UpdateProjectMutationFn = Apollo.MutationFunction<UpdateProjectMutation, UpdateProjectMutationVariables>;
+
+/**
+ * __useUpdateProjectMutation__
+ *
+ * To run a mutation, you first call `useUpdateProjectMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateProjectMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateProjectMutation, { data, loading, error }] = useUpdateProjectMutation({
+ *   variables: {
+ *      data: // value for 'data'
+ *   },
+ * });
+ */
+export function useUpdateProjectMutation(baseOptions?: Apollo.MutationHookOptions<UpdateProjectMutation, UpdateProjectMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateProjectMutation, UpdateProjectMutationVariables>(UpdateProjectDocument, options);
+      }
+export type UpdateProjectMutationHookResult = ReturnType<typeof useUpdateProjectMutation>;
+export type UpdateProjectMutationResult = Apollo.MutationResult<UpdateProjectMutation>;
+export type UpdateProjectMutationOptions = Apollo.BaseMutationOptions<UpdateProjectMutation, UpdateProjectMutationVariables>;
 export const DeleteTaskDocument = gql`
     mutation DeleteTask($id: Float!) {
   deleteTask(id: $id)

--- a/frontend/src/__generated__/graphql-types.ts
+++ b/frontend/src/__generated__/graphql-types.ts
@@ -132,6 +132,7 @@ export type Mutation = {
   deleteClient: Scalars['Boolean']['output'];
   deleteCompany: Scalars['Boolean']['output'];
   deleteDeliverable: Scalars['Boolean']['output'];
+  deleteProject: Scalars['Boolean']['output'];
   deleteTask: Scalars['Boolean']['output'];
   login: Scalars['String']['output'];
   setPasswordFromActivation: Scalars['Boolean']['output'];
@@ -201,6 +202,11 @@ export type MutationDeleteCompanyArgs = {
 
 export type MutationDeleteDeliverableArgs = {
   id: Scalars['Float']['input'];
+};
+
+
+export type MutationDeleteProjectArgs = {
+  projectId: Scalars['Float']['input'];
 };
 
 
@@ -481,6 +487,13 @@ export type UpdateProjectMutationVariables = Exact<{
 
 
 export type UpdateProjectMutation = { __typename?: 'Mutation', updateProject: { __typename?: 'Project', id: string, projectName: string, description?: string | null, endDate?: string | null } };
+
+export type DeleteProjectMutationVariables = Exact<{
+  projectId: Scalars['Float']['input'];
+}>;
+
+
+export type DeleteProjectMutation = { __typename?: 'Mutation', deleteProject: boolean };
 
 export type DeleteTaskMutationVariables = Exact<{
   id: Scalars['Float']['input'];
@@ -1044,6 +1057,37 @@ export function useUpdateProjectMutation(baseOptions?: Apollo.MutationHookOption
 export type UpdateProjectMutationHookResult = ReturnType<typeof useUpdateProjectMutation>;
 export type UpdateProjectMutationResult = Apollo.MutationResult<UpdateProjectMutation>;
 export type UpdateProjectMutationOptions = Apollo.BaseMutationOptions<UpdateProjectMutation, UpdateProjectMutationVariables>;
+export const DeleteProjectDocument = gql`
+    mutation DeleteProject($projectId: Float!) {
+  deleteProject(projectId: $projectId)
+}
+    `;
+export type DeleteProjectMutationFn = Apollo.MutationFunction<DeleteProjectMutation, DeleteProjectMutationVariables>;
+
+/**
+ * __useDeleteProjectMutation__
+ *
+ * To run a mutation, you first call `useDeleteProjectMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDeleteProjectMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [deleteProjectMutation, { data, loading, error }] = useDeleteProjectMutation({
+ *   variables: {
+ *      projectId: // value for 'projectId'
+ *   },
+ * });
+ */
+export function useDeleteProjectMutation(baseOptions?: Apollo.MutationHookOptions<DeleteProjectMutation, DeleteProjectMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteProjectMutation, DeleteProjectMutationVariables>(DeleteProjectDocument, options);
+      }
+export type DeleteProjectMutationHookResult = ReturnType<typeof useDeleteProjectMutation>;
+export type DeleteProjectMutationResult = Apollo.MutationResult<DeleteProjectMutation>;
+export type DeleteProjectMutationOptions = Apollo.BaseMutationOptions<DeleteProjectMutation, DeleteProjectMutationVariables>;
 export const DeleteTaskDocument = gql`
     mutation DeleteTask($id: Float!) {
   deleteTask(id: $id)

--- a/frontend/src/__tests__/integration/createProject.test.tsx
+++ b/frontend/src/__tests__/integration/createProject.test.tsx
@@ -14,7 +14,7 @@ import {
   it,
   vi,
 } from "vitest";
-import { CREATE_PROJECT } from "../../graphql-mutations/createproject";
+import { CREATE_PROJECT } from "../../graphql-mutations/project";
 import CreateProject from "../../pages/CreateProject";
 
 // Suppression des avertissements React Router

--- a/frontend/src/components/molecules/ProjectModal.tsx
+++ b/frontend/src/components/molecules/ProjectModal.tsx
@@ -33,7 +33,6 @@ export default function ProjectModal({
   const [endDate, setEndDate] = useState(project.endDate ?? "");
   const [description, setDescription] = useState(project.description ?? "");
 
-  console.info("name : ", name);
   useEffect(() => {
     setName(project.name);
     setEndDate(project.endDate ?? "");

--- a/frontend/src/components/molecules/ProjectModal.tsx
+++ b/frontend/src/components/molecules/ProjectModal.tsx
@@ -33,6 +33,7 @@ export default function ProjectModal({
   const [endDate, setEndDate] = useState(project.endDate ?? "");
   const [description, setDescription] = useState(project.description ?? "");
 
+  console.info("name : ", name);
   useEffect(() => {
     setName(project.name);
     setEndDate(project.endDate ?? "");
@@ -52,9 +53,6 @@ export default function ProjectModal({
       endDate: endDate || undefined,
       description: description.trim(),
     });
-
-    toast.success("Projet modifié !");
-    onClose();
   };
 
   const handleDelete = () => {
@@ -107,10 +105,7 @@ export default function ProjectModal({
           </button>
         </form>
 
-        <div className="border-t pt-4 mt-6">
-          <h3 className="text-sm font-medium text-gray-500 mb-2">
-            Supprimer ce projet
-          </h3>
+        <div className=" pt-4 mt-6">
           <button
             type="button"
             onClick={handleDelete}

--- a/frontend/src/graphql-mutations/project.ts
+++ b/frontend/src/graphql-mutations/project.ts
@@ -13,3 +13,14 @@ export const CREATE_PROJECT = gql`
     }
   }
 `;
+
+export const EDIT_PROJECT = gql`
+mutation UpdateProject($data: UpdateProjectInput!) {
+  updateProject(data: $data) {
+    id
+    projectName
+    description
+    endDate
+  }
+}
+`;

--- a/frontend/src/graphql-mutations/project.ts
+++ b/frontend/src/graphql-mutations/project.ts
@@ -24,3 +24,9 @@ mutation UpdateProject($data: UpdateProjectInput!) {
   }
 }
 `;
+
+export const DELETE_PROJECT = gql`
+  mutation DeleteProject($projectId: Float!) {
+    deleteProject(projectId: $projectId)
+  }
+`;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -27,6 +27,7 @@ import { ActivateAccountPage } from "@pages/ActivateAccountPage";
 import { SetPasswordPage } from "@pages/SetPasswordPage";
 import { ActivationErrorPage } from "@pages/ActivationTokenErrorPage";
 import ProjectDetails from "@pages/projectDetails/ProjectDetails";
+import NewAccount from "@components/organisms/NewAccount";
 
 const httpLink = new HttpLink({
   uri: import.meta.env.VITE_GRAPHQL_URI ?? "http://localhost:4000/graphql",
@@ -115,6 +116,10 @@ const router = createBrowserRouter([
       {
         path: "/activate",
         element: <ActivateAccountPage />,
+      },
+      {
+        path: "/newaccount",
+        element: <NewAccount user={"admin"} color={"bg-theme-base"} />,
       },
       {
         path: "*",

--- a/frontend/src/pages/projectDetails/ProjectDetails.tsx
+++ b/frontend/src/pages/projectDetails/ProjectDetails.tsx
@@ -25,7 +25,7 @@ const ProjectDetails = () => {
   const { slug } = useParams<{ slug: string }>();
   const navigate = useNavigate();
   const id = parseIdFromSlug(slug);
-  console.info("project details :");
+
   const { data, refetch } = useGetProjectByIdQuery({
     skip: id === null,
     variables: { id: id ?? 0 },
@@ -35,7 +35,6 @@ const ProjectDetails = () => {
     },
   });
   const [updateProjectMutation] = useUpdateProjectMutation();
-  console.info("data : ", data);
 
   const handleEditProject = async (updatedProject: {
     id: number;
@@ -44,7 +43,7 @@ const ProjectDetails = () => {
     description: string;
   }) => {
     if (!project) return;
-    console.info("Editing project with new name:", updatedProject);
+
     const payload: UpdateProjectInput = {
       id: String(updatedProject.id),
     };
@@ -74,7 +73,6 @@ const ProjectDetails = () => {
       const result = await updateProjectMutation({
         variables: { data: payload },
       });
-      console.info("result", result);
 
       toast.success("Projet mis à jour !");
       await refetch();

--- a/frontend/src/pages/projectDetails/ProjectDetails.tsx
+++ b/frontend/src/pages/projectDetails/ProjectDetails.tsx
@@ -67,7 +67,7 @@ const ProjectDetails = () => {
       payload.description === undefined &&
       payload.endDate === undefined
     ) {
-      toast.info("Aucune modification détectée.");
+      toast.info("No modification found.");
       return;
     }
 
@@ -76,15 +76,15 @@ const ProjectDetails = () => {
         variables: { data: payload },
       });
       if (result) {
-        toast.success("Projet mis à jour !");
+        toast.success("Projet updated !");
         await refetch();
         projectModal.closeModal();
       } else {
         console.error("Update error");
       }
     } catch (error) {
-      console.error("Erreur update :", error);
-      toast.error("Erreur lors de la mise à jour du projet.");
+      console.error("Update error :", error);
+      toast.error("Error when updating project.");
     }
   };
 
@@ -96,7 +96,7 @@ const ProjectDetails = () => {
         variables: { projectId: id },
       });
     } catch (error) {
-      console.error("Erreur dans deleteProjectMutation :", error);
+      console.error("Error in mutation :", error);
       throw error;
     }
   };
@@ -235,12 +235,12 @@ const ProjectDetails = () => {
 
           try {
             await handleDeleteProject(id);
-            toast.success("Projet supprimé avec succès !");
+            toast.success("Project successfully deleted !");
             deleteProjectModal.closeModal();
             navigate("/projects");
           } catch (error) {
-            toast.error("Échec de la suppression du projet.");
-            console.error("Erreur suppression :", error);
+            toast.error("Error when deleting project.");
+            console.error("Error when deleting project :", error);
           }
         }}
         onCancel={() => {

--- a/frontend/src/pages/projectDetails/ProjectDetails.tsx
+++ b/frontend/src/pages/projectDetails/ProjectDetails.tsx
@@ -20,6 +20,7 @@ import ProjectModal from "@components/molecules/ProjectModal";
 import { toast } from "react-toastify";
 import { useUpdateProjectMutation } from "@generated/graphql-types";
 import type { UpdateProjectInput } from "@generated/graphql-types";
+import { useDeleteProjectMutation } from "@generated/graphql-types";
 
 const ProjectDetails = () => {
   const { slug } = useParams<{ slug: string }>();
@@ -35,12 +36,13 @@ const ProjectDetails = () => {
     },
   });
   const [updateProjectMutation] = useUpdateProjectMutation();
+  const [deleteProjectMutation] = useDeleteProjectMutation();
 
   const handleEditProject = async (updatedProject: {
     id: number;
     name: string;
-    endDate: string;
-    description: string;
+    endDate?: string;
+    description?: string;
   }) => {
     if (!project) return;
 
@@ -73,10 +75,13 @@ const ProjectDetails = () => {
       const result = await updateProjectMutation({
         variables: { data: payload },
       });
-
-      toast.success("Projet mis à jour !");
-      await refetch();
-      projectModal.closeModal();
+      if (result) {
+        toast.success("Projet mis à jour !");
+        await refetch();
+        projectModal.closeModal();
+      } else {
+        console.error("Update error");
+      }
     } catch (error) {
       console.error("Erreur update :", error);
       toast.error("Erreur lors de la mise à jour du projet.");
@@ -85,11 +90,15 @@ const ProjectDetails = () => {
 
   const handleDeleteProject = async (id: number) => {
     console.info("Deleting project with ID:", id);
-    // if (!project) return;
-    // await deleteProjectMutation({
-    //   variables: { id: project.id },
-    // });
-    // navigate("/projects");
+
+    try {
+      await deleteProjectMutation({
+        variables: { projectId: id },
+      });
+    } catch (error) {
+      console.error("Erreur dans deleteProjectMutation :", error);
+      throw error;
+    }
   };
 
   // States and modals
@@ -220,12 +229,18 @@ const ProjectDetails = () => {
         open={deleteProjectModal.open}
         entityType="project"
         itemName={deleteProjectModal.data?.name ?? ""}
-        onConfirm={() => {
-          if (deleteProjectModal.data?.id) {
-            handleDeleteProject(deleteProjectModal.data.id);
-            toast.success("Project deleted successfully!");
+        onConfirm={async () => {
+          const id = deleteProjectModal.data?.id;
+          if (!id) return;
+
+          try {
+            await handleDeleteProject(id);
+            toast.success("Projet supprimé avec succès !");
             deleteProjectModal.closeModal();
             navigate("/projects");
+          } catch (error) {
+            toast.error("Échec de la suppression du projet.");
+            console.error("Erreur suppression :", error);
           }
         }}
         onCancel={() => {

--- a/frontend/src/pages/projectDetails/ProjectDetails.tsx
+++ b/frontend/src/pages/projectDetails/ProjectDetails.tsx
@@ -18,12 +18,14 @@ import type { InitialValues } from "@interfaces/type";
 import ArrowIcon from "@components/atoms/Icons/Arrow";
 import ProjectModal from "@components/molecules/ProjectModal";
 import { toast } from "react-toastify";
+import { useUpdateProjectMutation } from "@generated/graphql-types";
+import type { UpdateProjectInput } from "@generated/graphql-types";
 
 const ProjectDetails = () => {
   const { slug } = useParams<{ slug: string }>();
   const navigate = useNavigate();
   const id = parseIdFromSlug(slug);
-
+  console.info("project details :");
   const { data, refetch } = useGetProjectByIdQuery({
     skip: id === null,
     variables: { id: id ?? 0 },
@@ -32,15 +34,55 @@ const ProjectDetails = () => {
       console.error("Error fetching project details:", error);
     },
   });
+  const [updateProjectMutation] = useUpdateProjectMutation();
+  console.info("data : ", data);
 
-  const handleEditProject = async (newName: string) => {
-    console.info("Editing project with new name:", newName);
-    // if (!project) return;
-    // // mutation GraphQL ici
-    // await updateProjectMutation({
-    //   variables: { id: project.id, name: newName },
-    // });
-    // await refetch();
+  const handleEditProject = async (updatedProject: {
+    id: number;
+    name: string;
+    endDate: string;
+    description: string;
+  }) => {
+    if (!project) return;
+    console.info("Editing project with new name:", updatedProject);
+    const payload: UpdateProjectInput = {
+      id: String(updatedProject.id),
+    };
+
+    if (updatedProject.name !== project.projectName) {
+      payload.name = updatedProject.name;
+    }
+
+    if (updatedProject.description !== project.description) {
+      payload.description = updatedProject.description;
+    }
+
+    if (updatedProject.endDate !== project.endDate) {
+      payload.endDate = updatedProject.endDate;
+    }
+
+    if (
+      payload.name === undefined &&
+      payload.description === undefined &&
+      payload.endDate === undefined
+    ) {
+      toast.info("Aucune modification détectée.");
+      return;
+    }
+
+    try {
+      const result = await updateProjectMutation({
+        variables: { data: payload },
+      });
+      console.info("result", result);
+
+      toast.success("Projet mis à jour !");
+      await refetch();
+      projectModal.closeModal();
+    } catch (error) {
+      console.error("Erreur update :", error);
+      toast.error("Erreur lors de la mise à jour du projet.");
+    }
   };
 
   const handleDeleteProject = async (id: number) => {
@@ -166,7 +208,7 @@ const ProjectDetails = () => {
           description: project?.description ?? "",
         }}
         onEdit={(updatedProject) => {
-          handleEditProject(updatedProject.name);
+          handleEditProject(updatedProject);
         }}
         onDelete={(id) => {
           deleteProjectModal.openModal({


### PR DESCRIPTION
## ✨ Pull Request – Project Deletion Logic with Client & Account Deactivation

### ✅ What’s included in this PR

- Added `deleteProject` mutation in the backend
- Safely removes all deliverables linked to the project before deletion
- If the deleted project was the **last one for the client**:
  - The `Client` status is updated to `INACTIVE`
  - The associated `Account` status is also set to `INACTIVE`
- Added proper `GraphQLError` handling for:
  - Non-existent projects
  - Foreign key constraint violations
  - Unexpected server errors
- Updated frontend to:
  - Confirm deletion via modal
  - Trigger toast notifications
  - Navigate back to `/projects` after deletion
- TypeScript fixes to ensure strict typing of `ProjectModal` props

### 🧪 Tested

- Manual deletion from the UI
- Behavior when the client has multiple or only one project
- Error handling in edge cases


